### PR TITLE
Mem address gen

### DIFF
--- a/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
+++ b/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
@@ -1,0 +1,111 @@
+package maxpower.lmem.addressgenerators;
+
+import com.maxeler.maxcompiler.v0.utils.MathUtils;
+import com.maxeler.maxcompiler.v2.kernelcompiler.Kernel;
+import com.maxeler.maxcompiler.v2.kernelcompiler.KernelParameters;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.LMemCommandStream;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.Reductions;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.core.CounterChain;
+import com.maxeler.maxcompiler.v2.kernelcompiler.types.base.DFEType;
+import com.maxeler.maxcompiler.v2.kernelcompiler.types.base.DFEVar;
+import com.maxeler.maxcompiler.v2.kernelcompiler.types.composite.DFEStruct;
+
+public class MultiDimensionalAddressGenerator extends Kernel {
+
+	private final int latency = 3;//On multi-block case will output once every 4 cycles (this is as fast as the memory controller can handle, and allows for the latency of reading a ROM).
+
+	MultiDimensionalAddressGenerator(KernelParameters parameters, int numDimensions, int maxBlocks) {
+		super(parameters);
+		if (numDimensions > 2) {
+			throw new RuntimeException("Unsupported");
+		}
+		if (maxBlocks < 1) {
+			throw new RuntimeException("Unsupported");
+		}
+
+		DFEStruct cmd = LMemCommandStream.getLMemCommandDFEStructType().newInstance(this);
+		DFEType addressType = (DFEType)cmd["address"].getType();
+		DFEType sizeType    = (DFEType)cmd["size"].getType();
+
+		DFEVar numRepeats = io.scalarInput("numRepeats", dfeUInt(32));
+
+		DFEVar address;
+		DFEVar finalCmd;
+		DFEVar size;
+		DFEVar enableOutput;
+
+		if (maxBlocks == 1) {
+			DFEVar startAddress = io.scalarInput("startAddress", addressType);
+			DFEVar numBursts    = io.scalarInput("numBursts",    addressType);
+
+			CounterChain chain = control.count.makeCounterChain();
+			DFEVar repeat = chain.addCounter(numRepeats,   1);
+			finalCmd = repeat === numRepeats - 1;
+			if (numDimensions == 2) {
+				DFEVar size2d = io.scalarInput("size2d",    addressType);
+				DFEVar skip2d = io.scalarInput("skip2d",    addressType);
+				DFEVar pos2d  = chain.addCounter(size2d, 1);
+				finalCmd &= pos2d === size2d - 1;
+				startAddress += pos2d * skip2d;//TODO: use accumulator to avoid multiplication
+			}
+			DFEVar offset = chain.addCounter(numBursts,  128);
+			finalCmd &= offset + 128 >= numBursts;
+
+			enableOutput = constant.var(true);
+
+			DFEVar burstsLeft = numBursts - offset;
+			address  = startAddress + offset;
+			size     = burstsLeft < 128 ? burstsLeft.cast(sizeType) : 128;
+		} else {
+			DFEVar numBlocks = io.scalarInput("numBlocks", dfeUInt(MathUtils.bitsToRepresent(maxBlocks)));
+
+			DFEVar prevBlockNum = numBlocks.getType().newInstance(this);
+			DFEVar startAddress = mem.romMapped("startAddress", prevBlockNum, addressType, maxBlocks);
+			DFEVar numBursts    = mem.romMapped("numBursts",    prevBlockNum, addressType, maxBlocks);
+
+			CounterChain chain = control.count.makeCounterChain();
+			DFEVar repeat   = chain.addCounter(numRepeats,    1);
+			finalCmd = repeat === numRepeats - 1;
+			DFEVar blockNum = chain.addCounter(numBlocks,     1);
+			finalCmd &= blockNum === numBlocks - 1;
+			if (numDimensions == 2) {
+				DFEVar size2d = mem.romMapped("size2d", prevBlockNum, addressType, maxBlocks);
+				DFEVar skip2d = mem.romMapped("skip2d", prevBlockNum, addressType, maxBlocks);
+				DFEVar pos2d  = chain.addCounter(size2d, 1);
+				finalCmd &= pos2d === size2d - 1;
+				startAddress += pos2d * skip2d;//TODO: use accumulator to avoid multiplication
+			}
+			DFEVar offset   = chain.addCounter(numBursts,   128);
+			finalCmd &= offset + 128 >= numBursts;
+			DFEVar cycle    = chain.addCounter(latency + 1,   1);
+
+			prevBlockNum <== safeOffset(blockNum, -latency);
+			enableOutput = latency === cycle;
+
+			DFEVar burstsLeft = numBursts - offset;
+			address   = startAddress + offset;
+			size      = burstsLeft < 128 ? burstsLeft.cast(sizeType) : 128;
+			finalCmd &= enableOutput;
+		}
+
+		cmd["address"] = address;
+		cmd["size"]    = size;
+		cmd["inc"]     = constant.var((DFEType)cmd["inc"].getType(),    1);
+		cmd["stream"]  = constant.var((DFEType)cmd["stream"].getType(), 1);
+		cmd["tag"]     = finalCmd;
+
+		LMemCommandStream.makeKernelOutput("cmd", enableOutput, cmd);
+
+		DFEVar finished = Reductions.streamHold(finalCmd, finalCmd);
+		optimization.pushPipeliningFactor(0.0);
+		DFEVar trigger = finished & ~finalCmd;
+		optimization.popPipeliningFactor();
+
+		flush.onTrigger(trigger);
+	}
+
+	private DFEVar safeOffset(DFEVar input, int offset) {
+		DFEVar cycleCount = control.count.simpleCounter(48);
+		return cycleCount < -offset ? 0 : stream.offset(input, offset);
+	}
+}

--- a/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
+++ b/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
@@ -1,10 +1,12 @@
 package maxpower.lmem.addressgenerators;
 
-import com.maxeler.maxcompiler.v0.utils.MathUtils;
 import com.maxeler.maxcompiler.v2.kernelcompiler.Kernel;
 import com.maxeler.maxcompiler.v2.kernelcompiler.KernelParameters;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.Accumulator;
 import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.LMemCommandStream;
 import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.Reductions;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.core.Count.Params;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.core.Count.WrapMode;
 import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.core.CounterChain;
 import com.maxeler.maxcompiler.v2.kernelcompiler.types.base.DFEType;
 import com.maxeler.maxcompiler.v2.kernelcompiler.types.base.DFEVar;
@@ -12,6 +14,7 @@ import com.maxeler.maxcompiler.v2.kernelcompiler.types.composite.DFEStruct;
 import com.maxeler.maxcompiler.v2.managers.custom.CustomManager;
 import com.maxeler.maxcompiler.v2.managers.custom.DFELink;
 import com.maxeler.maxcompiler.v2.managers.custom.blocks.KernelBlock;
+import com.maxeler.maxcompiler.v2.utils.MathUtils;
 
 public class MultiDimensionalAddressGenerator extends Kernel {
 
@@ -88,7 +91,10 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 				DFEVar skipnd = io.scalarInput(getSkipNdName(dim), addressType);
 				DFEVar posnd  = chain.addCounter(sizend, 1);
 				finalCmd &= posnd === sizend - 1;
-				startAddress += posnd * skipnd;//TODO: use accumulator to avoid multiplication
+				Accumulator.Params config = Reductions.accumulator.makeAccumulatorConfig(addressType)
+					                                              .withClear(stream.offset(posnd === 0, 1))
+					                                              .withEnable(posnd !== safeOffset(posnd, -1) & posnd !== 0);
+				startAddress += Reductions.accumulator.makeAccumulator(skipnd, config);
 			}
 			DFEVar offset = chain.addCounter(numBursts,  128);
 			finalCmd &= offset + 128 >= numBursts;
@@ -115,7 +121,10 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 				DFEVar skipnd = mem.romMapped(getSkipNdName(dim), prevBlockNum, addressType, maxBlocks);
 				DFEVar posnd  = chain.addCounter(sizend, 1);
 				finalCmd &= posnd === sizend - 1;
-				startAddress += posnd * skipnd;//TODO: use accumulator to avoid multiplication
+				Accumulator.Params config = Reductions.accumulator.makeAccumulatorConfig(addressType)
+					                                              .withClear(stream.offset(posnd === 0, 1))
+					                                              .withEnable(posnd !== safeOffset(posnd, -1) & posnd !== 0);
+				startAddress += Reductions.accumulator.makeAccumulator(skipnd, config);
 			}
 			DFEVar offset   = chain.addCounter(numBursts,   128);
 			finalCmd &= offset + 128 >= numBursts;
@@ -146,8 +155,15 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 		flush.onTrigger(trigger);
 	}
 
+	//Avoid offsetting to before cycle 0.
 	private DFEVar safeOffset(DFEVar input, int offset) {
-		DFEVar cycleCount = control.count.simpleCounter(48);//TODO: use more complicated counter with fewer bits
+		if (offset > 0) {
+			throw new RuntimeException("safeOffset is only for negative stream offsets.");
+		}
+		Params params = control.count.makeParams(MathUtils.bitsToRepresent(-offset+1))
+		                             .withMax(-offset+1)
+		                             .withWrapMode(WrapMode.STOP_AT_MAX);
+		DFEVar cycleCount = control.count.makeCounter(params).getCount();
 		return cycleCount < -offset ? 0 : stream.offset(input, offset);
 	}
 

--- a/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
+++ b/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
@@ -16,7 +16,7 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 
 	MultiDimensionalAddressGenerator(KernelParameters parameters, int numDimensions, int maxBlocks) {
 		super(parameters);
-		if (numDimensions > 2) {
+		if (numDimensions < 1) {
 			throw new RuntimeException("Unsupported");
 		}
 		if (maxBlocks < 1) {
@@ -41,12 +41,12 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 			CounterChain chain = control.count.makeCounterChain();
 			DFEVar repeat = chain.addCounter(numRepeats,   1);
 			finalCmd = repeat === numRepeats - 1;
-			if (numDimensions == 2) {
-				DFEVar size2d = io.scalarInput("size2d",    addressType);
-				DFEVar skip2d = io.scalarInput("skip2d",    addressType);
-				DFEVar pos2d  = chain.addCounter(size2d, 1);
-				finalCmd &= pos2d === size2d - 1;
-				startAddress += pos2d * skip2d;//TODO: use accumulator to avoid multiplication
+			for (int dim = numDimensions; dim > 1; dim--) {
+				DFEVar sizend = io.scalarInput("size"+dim+"d", addressType);
+				DFEVar skipnd = io.scalarInput("skip"+dim+"d", addressType);
+				DFEVar posnd  = chain.addCounter(sizend, 1);
+				finalCmd &= posnd === sizend - 1;
+				startAddress += posnd * skipnd;//TODO: use accumulator to avoid multiplication
 			}
 			DFEVar offset = chain.addCounter(numBursts,  128);
 			finalCmd &= offset + 128 >= numBursts;
@@ -68,12 +68,12 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 			finalCmd = repeat === numRepeats - 1;
 			DFEVar blockNum = chain.addCounter(numBlocks,     1);
 			finalCmd &= blockNum === numBlocks - 1;
-			if (numDimensions == 2) {
-				DFEVar size2d = mem.romMapped("size2d", prevBlockNum, addressType, maxBlocks);
-				DFEVar skip2d = mem.romMapped("skip2d", prevBlockNum, addressType, maxBlocks);
-				DFEVar pos2d  = chain.addCounter(size2d, 1);
-				finalCmd &= pos2d === size2d - 1;
-				startAddress += pos2d * skip2d;//TODO: use accumulator to avoid multiplication
+			for (int dim = numDimensions; dim > 1; dim--) {
+				DFEVar sizend = mem.romMapped("size"+dim+"d", prevBlockNum, addressType, maxBlocks);
+				DFEVar skipnd = mem.romMapped("skip"+dim+"d", prevBlockNum, addressType, maxBlocks);
+				DFEVar posnd  = chain.addCounter(sizend, 1);
+				finalCmd &= posnd === sizend - 1;
+				startAddress += posnd * skipnd;//TODO: use accumulator to avoid multiplication
 			}
 			DFEVar offset   = chain.addCounter(numBursts,   128);
 			finalCmd &= offset + 128 >= numBursts;

--- a/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
+++ b/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
@@ -70,83 +70,68 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 
 		DFEStruct cmd = LMemCommandStream.getLMemCommandDFEStructType().newInstance(this);
 		DFEType addressType = (DFEType)cmd["address"].getType();
-		DFEType sizeType    = (DFEType)cmd["size"].getType();
 
 		DFEVar numRepeats = io.scalarInput(numRepeatsName, dfeUInt(32));
+		DFEVar numBlocks  = maxBlocks > 1
+		                  ? io.scalarInput(numBlocksName, dfeUInt(MathUtils.bitsToRepresent(maxBlocks)))
+		                  : null;
 
-		DFEVar address;
-		DFEVar finalCmd;
-		DFEVar size;
-		DFEVar enableOutput;
+		DFEVar prevBlockNum = maxBlocks > 1 ? numBlocks.getType().newInstance(this) : null;
+		DFEVar startAddress = scalarOrRom(startAddressName, prevBlockNum, addressType, maxBlocks);
+		DFEVar numBursts    = scalarOrRom(numBurstsName,    prevBlockNum, addressType, maxBlocks);
 
-		if (maxBlocks == 1) {
-			DFEVar startAddress = io.scalarInput(startAddressName, addressType);
-			DFEVar numBursts    = io.scalarInput(numBurstsName,    addressType);
+		CounterChain chain = control.count.makeCounterChain();
+		//Repeat all the whole sequence of commands numRepeats times before creating interrupt.
+		chain.addCounter(numRepeats, 1);
+		//Add an interrupt to the command when all the counters wrap
+		DFEVar finalCmd = chain.getCurrentCounterWrap();
 
-			CounterChain chain = control.count.makeCounterChain();
-			DFEVar repeat = chain.addCounter(numRepeats,   1);
-			finalCmd = repeat === numRepeats - 1;
-			for (int dim = numDimensions; dim > 1; dim--) {
-				DFEVar sizend = io.scalarInput(getSizeNdName(dim), addressType);
-				DFEVar skipnd = io.scalarInput(getSkipNdName(dim), addressType);
-				DFEVar posnd  = chain.addCounter(sizend, 1);
-				finalCmd &= posnd === sizend - 1;
-				Accumulator.Params config = Reductions.accumulator.makeAccumulatorConfig(addressType)
-					                                              .withClear(stream.offset(posnd === 0, 1))
-					                                              .withEnable(posnd !== safeOffset(posnd, -1) & posnd !== 0);
-				startAddress += Reductions.accumulator.makeAccumulator(skipnd, config);
-			}
-			DFEVar offset = chain.addCounter(numBursts,  128);
-			finalCmd &= offset + 128 >= numBursts;
-
-			enableOutput = constant.var(true);
-
-			DFEVar burstsLeft = numBursts - offset;
-			address  = startAddress + offset;
-			size     = burstsLeft < 128 ? burstsLeft.cast(sizeType) : 128;
-		} else {
-			DFEVar numBlocks = io.scalarInput(numBlocksName, dfeUInt(MathUtils.bitsToRepresent(maxBlocks)));
-
-			DFEVar prevBlockNum = numBlocks.getType().newInstance(this);
-			DFEVar startAddress = mem.romMapped(startAddressName, prevBlockNum, addressType, maxBlocks);
-			DFEVar numBursts    = mem.romMapped(numBurstsName,    prevBlockNum, addressType, maxBlocks);
-
-			CounterChain chain = control.count.makeCounterChain();
-			DFEVar repeat   = chain.addCounter(numRepeats,    1);
-			finalCmd = repeat === numRepeats - 1;
-			DFEVar blockNum = chain.addCounter(numBlocks,     1);
-			finalCmd &= blockNum === numBlocks - 1;
-			for (int dim = numDimensions; dim > 1; dim--) {
-				DFEVar sizend = mem.romMapped(getSizeNdName(dim), prevBlockNum, addressType, maxBlocks);
-				DFEVar skipnd = mem.romMapped(getSkipNdName(dim), prevBlockNum, addressType, maxBlocks);
-				DFEVar posnd  = chain.addCounter(sizend, 1);
-				finalCmd &= posnd === sizend - 1;
-				Accumulator.Params config = Reductions.accumulator.makeAccumulatorConfig(addressType)
-					                                              .withClear(stream.offset(posnd === 0, 1))
-					                                              .withEnable(posnd !== safeOffset(posnd, -1) & posnd !== 0);
-				startAddress += Reductions.accumulator.makeAccumulator(skipnd, config);
-			}
-			DFEVar offset   = chain.addCounter(numBursts,   128);
-			finalCmd &= offset + 128 >= numBursts;
-			DFEVar cycle    = chain.addCounter(latency + 1,   1);
-
+		if (maxBlocks > 1) {
+			//If we have multiple blocks, then add a counter to address the ROMs.
+			DFEVar blockNum = chain.addCounter(numBlocks, 1);
+			finalCmd = andWrap(chain, finalCmd);
+			//Using stream offset to cope with the loop around the ROMs and counter chain.
 			prevBlockNum <== safeOffset(blockNum, -latency);
-			enableOutput = latency === cycle;
-
-			DFEVar burstsLeft = numBursts - offset;
-			address   = startAddress + offset;
-			size      = burstsLeft < 128 ? burstsLeft.cast(sizeType) : 128;
-			finalCmd &= enableOutput;
 		}
 
-		cmd["address"] = address;
-		cmd["size"]    = size;
+		//Add an additional counter for all dimensions higher than 1 in reverse order.
+		for (int dim = numDimensions; dim > 1; dim--) {
+			DFEVar sizend = scalarOrRom(getSizeNdName(dim), prevBlockNum, addressType, maxBlocks);
+			DFEVar skipnd = scalarOrRom(getSkipNdName(dim), prevBlockNum, addressType, maxBlocks);
+			DFEVar posnd  = chain.addCounter(sizend, 1);
+			finalCmd = andWrap(chain, finalCmd);
+
+			//Using an accumulator to avoid using DPSs for calculating posnd * skipnd
+			Accumulator.Params config = Reductions.accumulator.makeAccumulatorConfig(addressType)
+				                                              .withClear(stream.offset(posnd === 0, 1))
+				                                              .withEnable(posnd !== safeOffset(posnd, -1) & posnd !== 0);
+			//Moving start address to the beginning of the current 1D strip.
+			startAddress += Reductions.accumulator.makeAccumulator(skipnd, config);
+		}
+
+		//Calculate the distance from start address in the 1D strip.
+		DFEVar offset = chain.addCounter(numBursts,   128);
+		finalCmd = andWrap(chain, finalCmd);
+
+		//All commands are 128 bursts until we reach the final command in our 1D strip.
+		DFEVar burstsLeft = (numBursts - offset).cast((DFEType)cmd["size"].getType());
+		DFEVar smallCmd   = chain.getCurrentCounterWrap();
+
+		//In the multi-block case we need to only output once every 4 cycles to cope with the loop latency.
+		DFEVar enableOutput = maxBlocks > 1
+		                    ? chain.addCounter(latency + 1, 1) === latency
+		                    : constant.var(true);
+
+		//Create output.
+		cmd["address"] = startAddress + offset;
+		cmd["size"]    = smallCmd ? burstsLeft : 128;
 		cmd["inc"]     = constant.var((DFEType)cmd["inc"].getType(),    1);
 		cmd["stream"]  = constant.var((DFEType)cmd["stream"].getType(), 1);
-		cmd["tag"]     = finalCmd;
+		cmd["tag"]     = finalCmd & enableOutput;
 
 		LMemCommandStream.makeKernelOutput(outputName, enableOutput, cmd);
 
+		//Flush after we have sent out the final command
 		DFEVar finished = Reductions.streamHold(finalCmd, finalCmd);
 		optimization.pushPipeliningFactor(0.0);
 		DFEVar trigger = finished & ~finalCmd;
@@ -160,11 +145,26 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 		if (offset > 0) {
 			throw new RuntimeException("safeOffset is only for negative stream offsets.");
 		}
-		Params params = control.count.makeParams(MathUtils.bitsToRepresent(-offset+1))
-		                             .withMax(-offset+1)
+		Params params = control.count.makeParams(MathUtils.bitsToRepresent(-offset))
+		                             .withMax(-offset)
 		                             .withWrapMode(WrapMode.STOP_AT_MAX);
 		DFEVar cycleCount = control.count.makeCounter(params).getCount();
 		return cycleCount < -offset ? 0 : stream.offset(input, offset);
+	}
+
+	//This ands in the wrap signal of the current counter. This is put in a method just to hide the pipelining factor.
+	private DFEVar andWrap(CounterChain chain, DFEVar wrap) {
+		DFEVar newWrap = chain.getCurrentCounterWrap();
+		optimization.pushPipeliningFactor(0.0);
+		DFEVar output = wrap & newWrap;
+		optimization.popPipeliningFactor();
+		return output;
+	}
+
+	//Create a scalar input if maxBlocks is 1, and a ROM otherwise.
+	private DFEVar scalarOrRom(String name, DFEVar address, DFEType type, int maxBlocks) {
+		return maxBlocks > 1 ? mem.romMapped(name, address, type, maxBlocks)
+						     : io.scalarInput(name, type);
 	}
 
 	/**

--- a/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
+++ b/src/maxpower/lmem/addressgenerators/MultiDimensionalAddressGenerator.maxj
@@ -9,25 +9,67 @@ import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.core.CounterChain;
 import com.maxeler.maxcompiler.v2.kernelcompiler.types.base.DFEType;
 import com.maxeler.maxcompiler.v2.kernelcompiler.types.base.DFEVar;
 import com.maxeler.maxcompiler.v2.kernelcompiler.types.composite.DFEStruct;
+import com.maxeler.maxcompiler.v2.managers.custom.CustomManager;
+import com.maxeler.maxcompiler.v2.managers.custom.DFELink;
+import com.maxeler.maxcompiler.v2.managers.custom.blocks.KernelBlock;
 
 public class MultiDimensionalAddressGenerator extends Kernel {
 
-	private final int latency = 3;//On multi-block case will output once every 4 cycles (this is as fast as the memory controller can handle, and allows for the latency of reading a ROM).
+	private static final int latency = 3;//On multi-block case will output once every 4 cycles (this is as fast as the memory controller can handle, and allows for the latency of reading a ROM).
 
-	MultiDimensionalAddressGenerator(KernelParameters parameters, int numDimensions, int maxBlocks) {
+	public static final String outputName       = "cmd";
+	public static final String numRepeatsName   = "numRepeats";
+	public static final String numBurstsName    = "numBursts";
+	public static final String startAddressName = "startAddress";
+	public static final String numBlocksName    = "numBlocks";
+
+	/**
+	 * A kernel that generates commands for reading or writing an N dimensional block from LMem.
+	 * This can be used as a replacement for the default address generators (linear, 3D blocking, etc).
+	 * </p>
+	 * There is no run cycle count to set, as it uses flush on trigger, but there are scalar inputs
+	 * and/or mapped ROMs to set to specify the size of the blocks to be read. Like the default
+	 * address generators, this will produce an interrupt when it is finished, which the CPU should
+	 * usually wait for.
+	 * </p>
+	 * The scalar inputs and mapped ROMs should be configured as follows:
+	 * <ul>
+	 * <li> numRepeats is the number of times you wish to repeat the same set of memory commands.
+	 * e.g if there are 3 blocks to read and you set numRepeats=2 then you will get 1,2,3,1,2,3. </li>
+	 * <li> numBlocks is the number of different blocks you want to read or write. If maxBlocks=1
+	 * then this scalar input doesn't exist. </li>
+	 * <li> startAddress is the address in bursts where the block begins. If maxBlocks is 1 then
+	 * this is a scalar input, otherwise it is a mapped ROM.</li>
+	 * <li> numBursts is the number of bursts to read linearly, i.e. the size of the fast dimension
+	 * for the current block. If maxBlocks is 1 then this is a scalar input, otherwise it is a mapped ROM.</li>
+	 * <li> sizeNd is size of the Nth dimension for N >= 2 for the current block. e.g. if you wish to read
+	 * an NxM block then numBursts is set to N/numElementsInBurst and size2d is set to M. If maxBlocks is 1
+	 * then these are scalar inputs, otherwise they are mapped ROMs.</li>
+	 * <li> skipNd is size of the jump we have to do in in order to in order to move in the Nth dimension
+	 * for N >= 2 for the current block. e.g. if you wish to read an NxM block from a KxL rectangle, then
+	 * skip2d is set to K/numElementsInBurst. If maxBlocks is 1 then these are scalar inputs, otherwise
+	 * they are mapped ROMs.</li>
+	 * </ul>
+	 * @param parameters KernelParameters for the kernel.
+	 * @param numDimensions The number of dimensions of the block we wish to read/write. The higher the
+	 * number, the more mapped ROMs or scalar inputs will be created for specifying the size in each dimension.
+	 * @param maxBlocks The maximum number of blocks to be read in a single action. If this is 1 then all mapped
+	 * ROMs become scalar inputs, otherwise this specifies the depth of the ROMs.
+	 */
+	public MultiDimensionalAddressGenerator(KernelParameters parameters, int numDimensions, int maxBlocks) {
 		super(parameters);
 		if (numDimensions < 1) {
-			throw new RuntimeException("Unsupported");
+			throw new RuntimeException("Number of dimensions must be at least 1.");
 		}
 		if (maxBlocks < 1) {
-			throw new RuntimeException("Unsupported");
+			throw new RuntimeException("Maximum number of blocks must be at least 1.");
 		}
 
 		DFEStruct cmd = LMemCommandStream.getLMemCommandDFEStructType().newInstance(this);
 		DFEType addressType = (DFEType)cmd["address"].getType();
 		DFEType sizeType    = (DFEType)cmd["size"].getType();
 
-		DFEVar numRepeats = io.scalarInput("numRepeats", dfeUInt(32));
+		DFEVar numRepeats = io.scalarInput(numRepeatsName, dfeUInt(32));
 
 		DFEVar address;
 		DFEVar finalCmd;
@@ -35,15 +77,15 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 		DFEVar enableOutput;
 
 		if (maxBlocks == 1) {
-			DFEVar startAddress = io.scalarInput("startAddress", addressType);
-			DFEVar numBursts    = io.scalarInput("numBursts",    addressType);
+			DFEVar startAddress = io.scalarInput(startAddressName, addressType);
+			DFEVar numBursts    = io.scalarInput(numBurstsName,    addressType);
 
 			CounterChain chain = control.count.makeCounterChain();
 			DFEVar repeat = chain.addCounter(numRepeats,   1);
 			finalCmd = repeat === numRepeats - 1;
 			for (int dim = numDimensions; dim > 1; dim--) {
-				DFEVar sizend = io.scalarInput("size"+dim+"d", addressType);
-				DFEVar skipnd = io.scalarInput("skip"+dim+"d", addressType);
+				DFEVar sizend = io.scalarInput(getSizeNdName(dim), addressType);
+				DFEVar skipnd = io.scalarInput(getSkipNdName(dim), addressType);
 				DFEVar posnd  = chain.addCounter(sizend, 1);
 				finalCmd &= posnd === sizend - 1;
 				startAddress += posnd * skipnd;//TODO: use accumulator to avoid multiplication
@@ -57,11 +99,11 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 			address  = startAddress + offset;
 			size     = burstsLeft < 128 ? burstsLeft.cast(sizeType) : 128;
 		} else {
-			DFEVar numBlocks = io.scalarInput("numBlocks", dfeUInt(MathUtils.bitsToRepresent(maxBlocks)));
+			DFEVar numBlocks = io.scalarInput(numBlocksName, dfeUInt(MathUtils.bitsToRepresent(maxBlocks)));
 
 			DFEVar prevBlockNum = numBlocks.getType().newInstance(this);
-			DFEVar startAddress = mem.romMapped("startAddress", prevBlockNum, addressType, maxBlocks);
-			DFEVar numBursts    = mem.romMapped("numBursts",    prevBlockNum, addressType, maxBlocks);
+			DFEVar startAddress = mem.romMapped(startAddressName, prevBlockNum, addressType, maxBlocks);
+			DFEVar numBursts    = mem.romMapped(numBurstsName,    prevBlockNum, addressType, maxBlocks);
 
 			CounterChain chain = control.count.makeCounterChain();
 			DFEVar repeat   = chain.addCounter(numRepeats,    1);
@@ -69,8 +111,8 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 			DFEVar blockNum = chain.addCounter(numBlocks,     1);
 			finalCmd &= blockNum === numBlocks - 1;
 			for (int dim = numDimensions; dim > 1; dim--) {
-				DFEVar sizend = mem.romMapped("size"+dim+"d", prevBlockNum, addressType, maxBlocks);
-				DFEVar skipnd = mem.romMapped("skip"+dim+"d", prevBlockNum, addressType, maxBlocks);
+				DFEVar sizend = mem.romMapped(getSizeNdName(dim), prevBlockNum, addressType, maxBlocks);
+				DFEVar skipnd = mem.romMapped(getSkipNdName(dim), prevBlockNum, addressType, maxBlocks);
 				DFEVar posnd  = chain.addCounter(sizend, 1);
 				finalCmd &= posnd === sizend - 1;
 				startAddress += posnd * skipnd;//TODO: use accumulator to avoid multiplication
@@ -94,7 +136,7 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 		cmd["stream"]  = constant.var((DFEType)cmd["stream"].getType(), 1);
 		cmd["tag"]     = finalCmd;
 
-		LMemCommandStream.makeKernelOutput("cmd", enableOutput, cmd);
+		LMemCommandStream.makeKernelOutput(outputName, enableOutput, cmd);
 
 		DFEVar finished = Reductions.streamHold(finalCmd, finalCmd);
 		optimization.pushPipeliningFactor(0.0);
@@ -105,7 +147,119 @@ public class MultiDimensionalAddressGenerator extends Kernel {
 	}
 
 	private DFEVar safeOffset(DFEVar input, int offset) {
-		DFEVar cycleCount = control.count.simpleCounter(48);
+		DFEVar cycleCount = control.count.simpleCounter(48);//TODO: use more complicated counter with fewer bits
 		return cycleCount < -offset ? 0 : stream.offset(input, offset);
+	}
+
+	/**
+	 * Adds kernel to manager and gets the command stream output.
+	 */
+	public static DFELink getCommandStream(MultiDimensionalAddressGenerator addressGenerator, CustomManager manager) {
+		KernelBlock kb = manager.addKernel(addressGenerator);
+		return kb.getOutput(outputName);
+	}
+
+	/**
+	 * Gets the name for the sizeNd ROM or scalar input for a given dimension.
+	 */
+	public static String getSizeNdName(int dimension) {
+		return "size"+dimension+"d";
+	}
+
+	/**
+	 * Gets the name for the skipNd ROM or scalar input for a given dimension.
+	 */
+	public static String getSkipNdName(int dimension) {
+		return "skip"+dimension+"d";
+	}
+
+	/**
+	 * Gets a stream from LMem that is controlled by the supplied address generator.
+	 */
+	public static DFELink addStreamFromOnCardMemory(String name, MultiDimensionalAddressGenerator addressGenerator, CustomManager manager) {
+		return manager.addStreamFromOnCardMemory(name, getCommandStream(addressGenerator, manager));
+	}
+
+	/**
+	 * Creates a stream to LMem that is controlled by the supplied address generator.
+	 */
+	public static DFELink addStreamToOnCardMemory(String name, MultiDimensionalAddressGenerator addressGenerator, CustomManager manager) {
+		return manager.addStreamToOnCardMemory(name, getCommandStream(addressGenerator, manager));
+	}
+
+	/**
+	 * Gets a stream that reads an N dimensional block from LMem.
+	 * This can be used as a replacement for the default address generators (linear, 3D blocking, etc).
+	 * </p>
+	 * There are scalar inputs and/or mapped ROMs to set to specify the size of the blocks to be read.
+	 * Like the default address generators, this will produce an interrupt when it is finished, which
+	 * the CPU should usually wait for.
+	 * </p>
+	 * The scalar inputs and mapped ROMs should be configured as follows:
+	 * <ul>
+	 * <li> numRepeats is the number of times you wish to repeat the same set of memory commands.
+	 * e.g if there are 3 blocks to read and you set numRepeats=2 then you will get 1,2,3,1,2,3. </li>
+	 * <li> numBlocks is the number of different blocks you want to read. If maxBlocks=1
+	 * then this scalar input doesn't exist. </li>
+	 * <li> startAddress is the address in bursts where the block begins. If maxBlocks is 1 then
+	 * this is a scalar input, otherwise it is a mapped ROM.</li>
+	 * <li> numBursts is the number of bursts to read linearly, i.e. the size of the fast dimension
+	 * for the current block. If maxBlocks is 1 then this is a scalar input, otherwise it is a mapped ROM.</li>
+	 * <li> sizeNd is size of the Nth dimension for N >= 2 for the current block. e.g. if you wish to read
+	 * an NxM block then numBursts is set to N/numElementsInBurst and size2d is set to M. If maxBlocks is 1
+	 * then these are scalar inputs, otherwise they are mapped ROMs.</li>
+	 * <li> skipNd is size of the jump we have to do in in order to in order to move in the Nth dimension
+	 * for N >= 2 for the current block. e.g. if you wish to read an NxM block from a KxL rectangle, then
+	 * skip2d is set to K/numElementsInBurst. If maxBlocks is 1 then these are scalar inputs, otherwise
+	 * they are mapped ROMs.</li>
+	 * </ul>
+	 * @param name The name for the memory stream.
+	 * @param manager The custom manager this is to be created in (this).
+	 * @param numDimensions The number of dimensions of the block we wish to read. The higher the
+	 * number, the more mapped ROMs or scalar inputs will be created for specifying the size in each dimension.
+	 * @param maxBlocks The maximum number of blocks to be read in a single action. If this is 1 then all mapped
+	 * ROMs become scalar inputs, otherwise this specifies the depth of the ROMs.
+	 */
+	public static DFELink addStreamFromOnCardMemory(String name, CustomManager manager, int numDimensions, int maxBlocks) {
+		MultiDimensionalAddressGenerator ag = new MultiDimensionalAddressGenerator(manager.makeKernelParameters(name+"CmdGen"), numDimensions, maxBlocks);
+		return addStreamFromOnCardMemory(name, ag, manager);
+	}
+
+	/**
+	 * Creates a stream that writes an N dimensional block to LMem.
+	 * This can be used as a replacement for the default address generators (linear, 3D blocking, etc).
+	 * </p>
+	 * There are scalar inputs and/or mapped ROMs to set to specify the size of the blocks to be written.
+	 * Like the default address generators, this will produce an interrupt when it is finished, which
+	 * the CPU should usually wait for.
+	 * </p>
+	 * The scalar inputs and mapped ROMs should be configured as follows:
+	 * <ul>
+	 * <li> numRepeats is the number of times you wish to repeat the same set of memory commands.
+	 * e.g if there are 3 blocks to write and you set numRepeats=2 then you will get 1,2,3,1,2,3. </li>
+	 * <li> numBlocks is the number of different blocks you want to write. If maxBlocks=1
+	 * then this scalar input doesn't exist. </li>
+	 * <li> startAddress is the address in bursts where the block begins. If maxBlocks is 1 then
+	 * this is a scalar input, otherwise it is a mapped ROM.</li>
+	 * <li> numBursts is the number of bursts to write linearly, i.e. the size of the fast dimension
+	 * for the current block. If maxBlocks is 1 then this is a scalar input, otherwise it is a mapped ROM.</li>
+	 * <li> sizeNd is size of the Nth dimension for N >= 2 for the current block. e.g. if you wish to write
+	 * an NxM block then numBursts is set to N/numElementsInBurst and size2d is set to M. If maxBlocks is 1
+	 * then these are scalar inputs, otherwise they are mapped ROMs.</li>
+	 * <li> skipNd is size of the jump we have to do in in order to in order to move in the Nth dimension
+	 * for N >= 2 for the current block. e.g. if you wish to write an NxM block into a KxL rectangle, then
+	 * skip2d is set to K/numElementsInBurst. If maxBlocks is 1 then these are scalar inputs, otherwise
+	 * they are mapped ROMs.</li>
+	 * </ul>
+	 * @param name The name for the memory stream.
+	 * @param manager The custom manager this is to be created in (this).
+	 * @param numDimensions The number of dimensions of the block we wish to write. The higher the
+	 * number, the more mapped ROMs or scalar inputs will be created for specifying the size in each dimension.
+	 * @param maxBlocks The maximum number of blocks to be written in a single action. If this is 1 then all mapped
+	 * ROMs become scalar inputs, otherwise this specifies the depth of the ROMs.
+	 */
+	public static DFELink addStreamToOnCardMemory(String name, CustomManager manager, int numDimensions, int maxBlocks) {
+		MultiDimensionalAddressGenerator ag = new MultiDimensionalAddressGenerator(manager.makeKernelParameters(name+"CmdGen"), numDimensions, maxBlocks);
+		return addStreamToOnCardMemory(name, ag, manager);
 	}
 }

--- a/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
+++ b/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
@@ -29,6 +29,7 @@ public class MultiDimensionalAddressGeneratorTest {
 		final int[] address;
 		final int[] size;
 		final int[] tag;
+
 		LAGTestData(int numDimensions, int numRepeats, int numBlocks) {
 			startAddress = new double[numBlocks];
 			numBursts    = new ArrayList<double[]>(numDimensions);

--- a/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
+++ b/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
@@ -1,5 +1,12 @@
 package maxpower.lmem.addressgenerators;
 
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.getSizeNdName;
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.getSkipNdName;
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.numBlocksName;
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.numBurstsName;
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.numRepeatsName;
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.outputName;
+import static maxpower.lmem.addressgenerators.MultiDimensionalAddressGenerator.startAddressName;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -127,26 +134,26 @@ public class MultiDimensionalAddressGeneratorTest {
 		LAGTestData data = new LAGTestData(numDimensions, numRepeats, numBlocks);
 
 		if (numBlocks == 1) {
-			mgr.setScalarInput("startAddress", data.startAddress[0]);
-			mgr.setScalarInput("numBursts", data.numBursts[0][0]);
+			mgr.setScalarInput(startAddressName, data.startAddress[0]);
+			mgr.setScalarInput(numBurstsName, data.numBursts[0][0]);
 			for (int dim = 2; dim <= numDimensions; dim++) {
-				mgr.setScalarInput("size"+dim+"d", data.numBursts[dim-1][0]);
-				mgr.setScalarInput("skip"+dim+"d", data.skipNd[dim-2][0]);
+				mgr.setScalarInput(getSizeNdName(dim), data.numBursts[dim-1][0]);
+				mgr.setScalarInput(getSkipNdName(dim), data.skipNd[dim-2][0]);
 			}
 		} else {
-			mgr.setMappedRom("startAddress", data.startAddress);
-			mgr.setMappedRom("numBursts", data.numBursts[0]);
-			mgr.setScalarInput("numBlocks", numBlocks);
+			mgr.setMappedRom(startAddressName, data.startAddress);
+			mgr.setMappedRom(numBurstsName, data.numBursts[0]);
+			mgr.setScalarInput(numBlocksName, numBlocks);
 			for (int dim = 2; dim <= numDimensions; dim++) {
-				mgr.setMappedRom("size"+dim+"d", data.numBursts[dim-1]);
-				mgr.setMappedRom("skip"+dim+"d", data.skipNd[dim-2]);
+				mgr.setMappedRom(getSizeNdName(dim), data.numBursts[dim-1]);
+				mgr.setMappedRom(getSkipNdName(dim), data.skipNd[dim-2]);
 			}
 		}
-		mgr.setScalarInput("numRepeats",   numRepeats);
+		mgr.setScalarInput(numRepeatsName,   numRepeats);
 
 		mgr.runTest();
 
-		List<Map<String,Double>> output = mgr.getOutputData(LMemCommandStream.getLMemCommandDFEStructType(), "cmd");
+		List<Map<String,Double>> output = mgr.getOutputData(LMemCommandStream.getLMemCommandDFEStructType(), outputName);
 		assertTrue(data.checkOutput(output));
 	}
 }

--- a/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
+++ b/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
@@ -112,6 +112,12 @@ public class MultiDimensionalAddressGeneratorTest {
 	@Test public void test_single_block_2d()       { test(2, 2, 1); }
 	@Test public void test_multi_block_2d()        { test(2, 2, 3); }
 
+	@Test public void test_single_block_3d()       { test(3, 2, 1); }
+	@Test public void test_multi_block_3d()        { test(3, 2, 3); }
+
+	@Test public void test_single_block_4d()       { test(4, 2, 1); }
+	@Test public void test_multi_block_4d()        { test(4, 2, 3); }
+
 	private void test(int numDimensions, int numRepeats, int numBlocks) {
 		SimulationManager mgr = new SimulationManager("MultiDimensionalAddressGeneratorTest_" + numDimensions + "D_"+ numBlocks + "blocks");
 
@@ -123,17 +129,17 @@ public class MultiDimensionalAddressGeneratorTest {
 		if (numBlocks == 1) {
 			mgr.setScalarInput("startAddress", data.startAddress[0]);
 			mgr.setScalarInput("numBursts", data.numBursts[0][0]);
-			if (numDimensions == 2) {
-				mgr.setScalarInput("size2d", data.numBursts[1][0]);
-				mgr.setScalarInput("skip2d", data.skipNd[0][0]);
+			for (int dim = 2; dim <= numDimensions; dim++) {
+				mgr.setScalarInput("size"+dim+"d", data.numBursts[dim-1][0]);
+				mgr.setScalarInput("skip"+dim+"d", data.skipNd[dim-2][0]);
 			}
 		} else {
 			mgr.setMappedRom("startAddress", data.startAddress);
 			mgr.setMappedRom("numBursts", data.numBursts[0]);
 			mgr.setScalarInput("numBlocks", numBlocks);
-			if (numDimensions == 2) {
-				mgr.setMappedRom("size2d", data.numBursts[1]);
-				mgr.setMappedRom("skip2d", data.skipNd[0]);
+			for (int dim = 2; dim <= numDimensions; dim++) {
+				mgr.setMappedRom("size"+dim+"d", data.numBursts[dim-1]);
+				mgr.setMappedRom("skip"+dim+"d", data.skipNd[dim-2]);
 			}
 		}
 		mgr.setScalarInput("numRepeats",   numRepeats);

--- a/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
+++ b/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
@@ -1,0 +1,146 @@
+package maxpower.lmem.addressgenerators;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Test;
+
+import com.maxeler.maxcompiler.v0.utils.MathUtils;
+import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.LMemCommandStream;
+import com.maxeler.maxcompiler.v2.managers.standard.SimulationManager;
+
+public class MultiDimensionalAddressGeneratorTest {
+
+	private class LAGTestData {
+		final double[] startAddress;
+		final List<double[]> numBursts;
+		final List<double[]> skipNd;
+		final int[] address;
+		final int[] size;
+		final int[] tag;
+		LAGTestData(int numDimensions, int numRepeats, int numBlocks) {
+			startAddress = new double[numBlocks];
+			numBursts    = new ArrayList<double[]>(numDimensions);
+			skipNd       = new ArrayList<double[]>(numDimensions - 1);
+			numBursts.add(new double[numBlocks]);
+			for (int i = 1; i < numDimensions; i++) {
+				numBursts.add(new double[numBlocks]);
+				skipNd.add(new double[numBlocks]);
+			}
+
+			long seed = System.currentTimeMillis();
+			System.out.println("Using seed " + seed);
+			Random rand = new Random(seed);
+			for (int i = 0; i < numBlocks; i++) {
+				startAddress[i] = rand.nextInt(1024);
+				numBursts[0][i] = 1 + rand.nextInt(1024);
+				for (int j = 1; j < numDimensions; j++) {
+					numBursts[j][i] = 1 + rand.nextInt(10);
+					skipNd[j-1][i]  = numBursts[0][i] + rand.nextInt(1024);
+				}
+			}
+
+			int numCmds = 0;
+			for (int i = 0; i < numBlocks; i++) {
+				int nb = MathUtils.ceilDivide((int)numBursts[0][i], 128);
+				for (int j = 1; j < numDimensions; j++) {
+					nb *= numBursts[j][i];
+				}
+				numCmds += nb * numRepeats;
+			}
+
+			address = new int[numCmds];
+			size    = new int[numCmds];
+			tag     = new int[numCmds];
+
+			int idx = 0;
+			for (int i = 0; i < numBlocks; i++) {
+				idx = fillAddresses((int)startAddress[i], idx, numDimensions - 1, numDimensions, i);
+			}
+			for (int i = numCmds / numRepeats; i < numCmds; i++) {
+				address[i] = address[i - numCmds / numRepeats];
+				size[i]    = size[i - numCmds / numRepeats];
+			}
+			for (int i = 0; i < numCmds; i++) {
+				tag[i] = (i == numCmds - 1 ? 1 : 0);
+			}
+		}
+
+		int fillAddresses(int startAdd, int idx, int dimension, int numDimensions, int blockNum) {
+			if (dimension == 0) {
+				for (int k = 0; k < MathUtils.ceilDivide((int)numBursts[0][blockNum], 128); k++) {
+					address[idx] = startAdd + k * 128;
+					size[idx]    = k * 128 + 128 > numBursts[0][blockNum] ? (int)numBursts[0][blockNum] - k * 128 : 128;
+					idx++;
+				}
+			} else {
+				for (int i = 0; i < numBursts[dimension][blockNum]; i++) {
+					idx = fillAddresses(startAdd + i * (int)skipNd[dimension - 1][blockNum], idx, dimension - 1, numDimensions, blockNum);
+				}
+			}
+			return idx;
+		}
+
+		boolean checkOutput(List<Map<String,Double>> output) {
+			if (output.size() != address.length) {
+				System.out.println("Output is the wrong length. Expected " + address.length + ", got " + output.size());
+				return false;
+			}
+			boolean correct = true;
+			for (int i = 0; i < output.size(); i++) {
+				boolean correctAddress = output[i]["address"] == address[i];
+				boolean correctSize    = output[i]["size"]    == size[i];
+				boolean correctTag     = output[i]["tag"]     == tag[i];
+
+				if (!correctAddress) System.out.println("Address wrong on command number " + i +". Expected " + address[i] + ", got " + output[i]["address"]);
+				if (!correctSize)    System.out.println("Size wrong on command number "    + i +". Expected " + size[i]    + ", got " + output[i]["size"]);
+				if (!correctTag)     System.out.println("Tag wrong on command number "     + i +". Expected " + tag[i]     + ", got " + output[i]["tag"]);
+
+				correct &= correctAddress & correctSize && correctTag;
+			}
+			return correct;
+		}
+	}
+
+	@Test public void test_single_block_1d()       { test(1, 5, 1); }
+	@Test public void test_multi_block_1d()        { test(1, 5, 3); }
+
+	@Test public void test_single_block_2d()       { test(2, 2, 1); }
+	@Test public void test_multi_block_2d()        { test(2, 2, 3); }
+
+	private void test(int numDimensions, int numRepeats, int numBlocks) {
+		SimulationManager mgr = new SimulationManager("MultiDimensionalAddressGeneratorTest_" + numDimensions + "D_"+ numBlocks + "blocks");
+
+		MultiDimensionalAddressGenerator kernel = new MultiDimensionalAddressGenerator(mgr.makeKernelParameters(), numDimensions, numBlocks);
+		mgr.setKernel(kernel);
+
+		LAGTestData data = new LAGTestData(numDimensions, numRepeats, numBlocks);
+
+		if (numBlocks == 1) {
+			mgr.setScalarInput("startAddress", data.startAddress[0]);
+			mgr.setScalarInput("numBursts", data.numBursts[0][0]);
+			if (numDimensions == 2) {
+				mgr.setScalarInput("size2d", data.numBursts[1][0]);
+				mgr.setScalarInput("skip2d", data.skipNd[0][0]);
+			}
+		} else {
+			mgr.setMappedRom("startAddress", data.startAddress);
+			mgr.setMappedRom("numBursts", data.numBursts[0]);
+			mgr.setScalarInput("numBlocks", numBlocks);
+			if (numDimensions == 2) {
+				mgr.setMappedRom("size2d", data.numBursts[1]);
+				mgr.setMappedRom("skip2d", data.skipNd[0]);
+			}
+		}
+		mgr.setScalarInput("numRepeats",   numRepeats);
+
+		mgr.runTest();
+
+		List<Map<String,Double>> output = mgr.getOutputData(LMemCommandStream.getLMemCommandDFEStructType(), "cmd");
+		assertTrue(data.checkOutput(output));
+	}
+}

--- a/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
+++ b/test/maxpower/lmem/addressgenerators/MultiDimensionalAddressGeneratorTest.maxj
@@ -16,13 +16,13 @@ import java.util.Random;
 
 import org.junit.Test;
 
-import com.maxeler.maxcompiler.v0.utils.MathUtils;
 import com.maxeler.maxcompiler.v2.kernelcompiler.stdlib.LMemCommandStream;
 import com.maxeler.maxcompiler.v2.managers.standard.SimulationManager;
+import com.maxeler.maxcompiler.v2.utils.MathUtils;
 
 public class MultiDimensionalAddressGeneratorTest {
 
-	private class LAGTestData {
+	private class MDAGTestData {
 		final double[] startAddress;
 		final List<double[]> numBursts;
 		final List<double[]> skipNd;
@@ -30,7 +30,7 @@ public class MultiDimensionalAddressGeneratorTest {
 		final int[] size;
 		final int[] tag;
 
-		LAGTestData(int numDimensions, int numRepeats, int numBlocks) {
+		MDAGTestData(int numDimensions, int numRepeats, int numBlocks) {
 			startAddress = new double[numBlocks];
 			numBursts    = new ArrayList<double[]>(numDimensions);
 			skipNd       = new ArrayList<double[]>(numDimensions - 1);
@@ -132,7 +132,7 @@ public class MultiDimensionalAddressGeneratorTest {
 		MultiDimensionalAddressGenerator kernel = new MultiDimensionalAddressGenerator(mgr.makeKernelParameters(), numDimensions, numBlocks);
 		mgr.setKernel(kernel);
 
-		LAGTestData data = new LAGTestData(numDimensions, numRepeats, numBlocks);
+		MDAGTestData data = new MDAGTestData(numDimensions, numRepeats, numBlocks);
 
 		if (numBlocks == 1) {
 			mgr.setScalarInput(startAddressName, data.startAddress[0]);


### PR DESCRIPTION
This is an N-dimensional blocking address generator. It performs the same function as the 3D blocking address generator (and so can easily replace it), except that it also works for any number of dimensions (including 1, which means it can also replace the linear address generator).

A major advantage over the regular address generators is that you can specify multiple blocks to be read from memory, which would allow a MaxGenFD style application to run a whole timestep without a reset. There is another option to get it to repeat a set pattern many times, which means a MaxGenFD style application could actually run every timestep with a single action.

Basically this is what you would need if you wanted to do MaxGenFD (or any grid based computation) properly in any number of dimensions, but it could also be used for many other things.

Another advantage is that this doesn't require a reset, so it might be possible to use it in a networking application, although I can't think of a use case.

