### PR TITLE
use getOwner instead of getKernel in FanoutLimiter

### DIFF
--- a/src/maxpower/kernel/pipeline/FanoutLimiter.maxj
+++ b/src/maxpower/kernel/pipeline/FanoutLimiter.maxj
@@ -42,7 +42,7 @@ public class FanoutLimiter<T extends KernelObject<T>> extends KernelComponent im
 	 * @param maxFanout The maximum number of places to fan out to without adding a register.
 	 */
 	public FanoutLimiter(T source, int maxFanout) {
-		super(source.getKernel());
+		super(source.getOwner());
 
 		if (maxFanout < 2)
 			throw new MaxCompilerAPIError("maxFanout must be >= 2, not " + maxFanout);


### PR DESCRIPTION
Following Step's suggestions to change getKernel() to getOwner()  in FanoutLimiter in order to build with KernelLite